### PR TITLE
fix: on-error need to be invoke before the template

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -96,5 +96,5 @@ dryrun="${PLUGIN_DRY_RUN:-${dryrun}}"
 if [ "${dryrun}" == "true" ]; then
   packer validate ${inclusions} ${to_skip} ${to_build} ${include_vars} "${target}"
 else
-  packer build ${inclusions} ${to_skip} ${to_build} ${include_vars} "${target}" -on-error="${on_error}"
+  packer build -on-error="${on_error}" ${inclusions} ${to_skip} ${to_build} ${include_vars} "${target}"
 fi


### PR DESCRIPTION
# What's this PR about?

Fixing #6, template.json should be the last element of the CLI

# Some resources?

the output of the build in drone: 
```
Usage: packer build [options] TEMPLATE

  Will execute multiple builds in parallel as defined in the template.
  The various artifacts created by the template will be outputted.

Options:

  -color=false               Disable color output (on by default)
  -debug                     Debug mode enabled for builds
  -except=foo,bar,baz        Build all builds other than these
  -only=foo,bar,baz          Build only the specified builds
  -force                     Force a build to continue if artifacts exist, deletes existing artifacts
  -machine-readable          Machine-readable output
  -on-error=[cleanup|abort|ask] If the build fails do: clean up (default), abort, or ask
  -parallel=false            Disable parallelization (on by default)
  -var 'key=value'           Variable for templates, can be used multiple times.
  -var-file=path             JSON file containing user variables.
``` 

