### PR TITLE
fix: remove double quote in on_error value

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -6,7 +6,7 @@ session_id="${DRONE_COMMIT_SHA:0:10}-${DRONE_BUILD_NUMBER}"
 account_id=${PLUGIN_ACCOUNT:-'none'}
 aws_credentials_ttl=${PLUGIN_AWS_CREDENTIALS_TTL:-'3600'}
 aws_region=${PLUGIN_AWS_REGION:-'us-east-1'}
-on_error="${PLUGIN_ON_ERROR:-'cleanup'}"
+on_error=${PLUGIN_ON_ERROR:-'cleanup'}
 
 # Functions
 function pdebug {
@@ -96,5 +96,5 @@ dryrun="${PLUGIN_DRY_RUN:-${dryrun}}"
 if [ "${dryrun}" == "true" ]; then
   packer validate ${inclusions} ${to_skip} ${to_build} ${include_vars} "${target}"
 else
-  packer build -on-error="${on_error}" ${inclusions} ${to_skip} ${to_build} ${include_vars} "${target}"
+  packer build -on-error=${on_error} ${inclusions} ${to_skip} ${to_build} ${include_vars} "${target}"
 fi


### PR DESCRIPTION
# What's this PR about?

removing double quote in the variable for `on_error` feature

# Related PR?

fix #7 #6 

# Some resources?

The drone output:

```
Usage: packer build [options] TEMPLATE

  Will execute multiple builds in parallel as defined in the template.
  The various artifacts created by the template will be outputted.

Options:

  -color=false               Disable color output (on by default)
  -debug                     Debug mode enabled for builds
  -except=foo,bar,baz        Build all builds other than these
  -only=foo,bar,baz          Build only the specified builds
  -force                     Force a build to continue if artifacts exist, deletes existing artifacts
  -machine-readable          Machine-readable output
  -on-error=[cleanup|abort|ask] If the build fails do: clean up (default), abort, or ask
  -parallel=false            Disable parallelization (on by default)
  -var 'key=value'           Variable for templates, can be used multiple times.
  -var-file=path             JSON file containing user variables.
invalid value "'cleanup'" for flag -on-error: expected one of ["cleanup" "abort" "ask"]
```