### PR TITLE
Adding Ansible to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ COPY runner.sh /bin/runner.sh
 
 RUN apk --no-cache --update add bash \
     openssl \
-    ca-certificates
+    ca-certificates \
+    openssh
+
+RUN apk --no-cache --update add ansible; exit 0
 
 RUN wget https://releases.hashicorp.com/packer/1.2.2/packer_1.2.2_linux_amd64.zip -O packer.zip && \
     unzip packer.zip -d /usr/bin/ && \


### PR DESCRIPTION
This will add Ansible package to the Docker image, needed to run [Ansible Packer provisioner](https://www.packer.io/docs/provisioners/ansible.html).

Installation has been tested locally on the [Alpine 3.6 base image](https://github.com/mesosphere/aws-cli/blob/master/Dockerfile#L1)