### PR TITLE
feat: Make root_dir configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM mesosphere/aws-cli
 
-COPY runner.sh /bin/runner.sh
-
 RUN apk --no-cache --update add bash \
     openssl \
     ca-certificates \
@@ -12,5 +10,7 @@ RUN apk --no-cache --update add ansible; exit 0
 RUN wget https://releases.hashicorp.com/packer/1.2.2/packer_1.2.2_linux_amd64.zip -O packer.zip && \
     unzip packer.zip -d /usr/bin/ && \
     rm -f packer.zip
+
+COPY runner.sh /bin/runner.sh
 
 ENTRYPOINT ["/bin/bash", "/bin/runner.sh"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ pipeline:
   build:
     image: quay.io/heetch/drone-packer
     include_files: [ config/common.json, config/<target> ]
+    root_dir: src/services/app/delivery/app-pk
     target: base.json
     variables:
         name: packer
@@ -21,6 +22,7 @@ pipeline:
 
  - `account`: AWS account ID in which to assume the role. Instance IAM role will be used by default
  - `use_ci_role`: IAM role name to use. Defaults to `ci`. Ignored if `account` is not provided
+ - `root_dir`: The root directory where the packer files live. When unset, the top level directory will be assumed.
  - `target`: Name of target packer template to execute
  - `variables`: Optional variables to pass to packer build command
  - `secret_variables`: List of variables to be read from environment
@@ -32,6 +34,7 @@ pipeline:
 
 ## Notes
 
+ - `root_dir` is a relative path to repository root.
  - `target` must be the name of the target template. `target` can be provided as plugin parameter
    in .drone.yml file or it can be passed as deployment parameter using either drone CLI or
    github deployment api.

--- a/runner.sh
+++ b/runner.sh
@@ -19,6 +19,13 @@ if [ "${account_id}" == "none" ]; then
   account_id="IAM Role"
 fi
 
+# Get the root_dir for packer files
+root_dir="${PLUGIN_ROOT_DIR:-${root_dir}}"
+if [ "${root_dir}" != "" ]; then
+  echo "Root Dir: ${root_dir}"
+  cd "${root_dir}" || exit 1
+fi
+
 # Print authentication infos
 echo "AWS credentials meta:"
 echo "  CI Role: ${ci_role}"


### PR DESCRIPTION
For our `cosmos` builds we need `root_dir` to be configurable.

Tested in CI here: https://drone-131.heetch.net/heetch/cosmos/137